### PR TITLE
add vendor button is disabled when edit form appears

### DIFF
--- a/src/javascripts/components/forms/editVendorForm.js
+++ b/src/javascripts/components/forms/editVendorForm.js
@@ -35,6 +35,7 @@ const editVendorForm = (vendorId) => {
   vendorData.getSingleVendor(vendorId)
     .then((response) => {
       vendorView.vendorView();
+      $('#add-vendor-btn').attr('disabled', true);
       $('#app').append(`
       <form id="editVendorForm">
         <h2>Edit a Vendor</h2>


### PR DESCRIPTION

## Description
add vendor button is disabled when edit form appears

## Related Issue
n/a

## Motivation and Context
user experience is better this way

## How Can This Be Tested?
git fetch dp-edit-vendor-fix

## Screenshots (if appropriate):
n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)