### PR TITLE
updated staff selection to only show unassigned staff

### DIFF
--- a/src/javascripts/components/forms/addDinoForm.js
+++ b/src/javascripts/components/forms/addDinoForm.js
@@ -29,7 +29,7 @@ const addDinoForm = () => {
   staffData.getStaff().then((response) => {
     response.forEach((item) => {
       // This retrieves a staff name only if it is not assigned with a dinoId
-      if (!(item.dinoId)) {
+      if (!(item.dinoId || item.rideId || item.vendorId)) {
         $('select').append(`<option value="${item.staffId}">${item.name}</option>`);
       }
     });

--- a/src/javascripts/components/forms/addRideForm.js
+++ b/src/javascripts/components/forms/addRideForm.js
@@ -30,7 +30,7 @@ const rideForm = () => {
   );
   staffData.getStaff().then((response) => {
     response.forEach((item) => {
-      if (!(item.rideId)) {
+      if (!(item.dinoId || item.rideId || item.vendorId)) {
         $('select').append(`<option value="${item.staffId}">${item.name}</option>`);
       }
     });

--- a/src/javascripts/components/forms/editDinoForm.js
+++ b/src/javascripts/components/forms/editDinoForm.js
@@ -35,7 +35,7 @@ const editDinoForm = (dinoObject) => {
   staffData.getStaff().then((response) => {
     response.forEach((item) => {
       // This retrieves a staff name only if it is not assigned with a dinoId
-      if (!(item.dinoId && dinoObject.dinoId !== item.dinoId)) {
+      if (!(item.rideId || item.vendorId || item.dinoId || dinoObject.dinoId === item.dinoId)) {
         $('select').append(
           `<option value="${item.staffId}" ${
             dinoObject.staffId === item.staffId ? "selected ='selected'" : ''

--- a/src/javascripts/components/forms/editRideForm.js
+++ b/src/javascripts/components/forms/editRideForm.js
@@ -33,7 +33,7 @@ const editRideForm = (rideObject) => {
 </form>`);
   staffData.getStaff().then((response) => {
     response.forEach((item) => {
-      if (!(item.rideId && rideObject.rideId !== item.rideId)) {
+      if (!(item.rideId || item.dinoId || item.vendorId || rideObject.rideId === item.rideId)) {
         $('select').append(
           `<option value="${item.staffId}" ${
             rideObject.staffId === item.staffId ? "selected ='selected'" : ''

--- a/src/javascripts/components/forms/editVendorForm.js
+++ b/src/javascripts/components/forms/editVendorForm.js
@@ -62,7 +62,7 @@ const editVendorForm = (vendorId) => {
     });
   staffData.getStaff().then((response) => {
     response.forEach((item) => {
-      if (!(item.vendorId)) {
+      if (!(item.vendorId || item.dinoId || item.rideId)) {
         $('select').append(
           `<option value="${item.staffId}">${item.name}</option>`
         );

--- a/src/javascripts/components/forms/vendorForm.js
+++ b/src/javascripts/components/forms/vendorForm.js
@@ -26,7 +26,7 @@ const vendorForm = () => {
   </form>`);
   staffData.getStaff().then((response) => {
     response.forEach((item) => {
-      if (!(item.vendorId)) {
+      if (!(item.dinoId || item.rideId || item.vendorId)) {
         $('select').append(`<option value="${item.staffId}">${item.name}</option>`);
       }
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- DELETE ALL COMMENTS BEFORE CREATING PULL REQUEST -->

## Description
Allows users to only assign staff that are not assigned to other duties

## Related Issue
closes #109 

## Motivation and Context
Allows only one staff selection per duty

## How Can This Be Tested?
git fetch
git checkout single-assign

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)